### PR TITLE
Add update action to remote navigation

### DIFF
--- a/lib/shimmer/utils/remote_navigation.rb
+++ b/lib/shimmer/utils/remote_navigation.rb
@@ -69,6 +69,10 @@ module Shimmer
       queued_updates.push turbo_stream.append "shimmer", "<div class='hidden' data-controller='remote-navigation'>#{script}</div>"
     end
 
+    def update(id, with: id, **locals)
+      queued_updates.push turbo_stream.update(id, partial: with, locals: locals)
+    end
+
     def replace(id, with: id, **locals)
       queued_updates.push turbo_stream.replace(id, partial: with, locals: locals)
     end


### PR DESCRIPTION
Shimmer is missing the update action in remote navigation. This action allows the application to replace the contents of a window without actually replacing the entire div.

Reference

https://turbo.hotwired.dev/reference/streams