### PR TITLE
add guards to db commands

### DIFF
--- a/lib/shimmer/tasks/db.rake
+++ b/lib/shimmer/tasks/db.rake
@@ -3,9 +3,18 @@
 namespace :db do
   desc "Downloads the app database from Heroku and imports it to the local database"
   task pull_data: :environment do
+    unless system("which heroku > /dev/null 2>&1")
+      if system("which brew > /dev/null 2>&1")
+        puts "Heroku CLI is not installed. Please install it with the command: brew tap heroku/brew && brew install heroku"
+      else
+        puts "AWS CLI is not installed. Please install it to continue."
+      end
+      exit(1)
+    end
+
     unless system("heroku apps:info")
       puts "Heroku remote is not set. Please add a Heroku remote with `heroku git:remote -a your-app-name`."
-      next
+      exit(1)
     end
 
     config = if Rails.version.to_f >= 7

--- a/lib/shimmer/tasks/db.rake
+++ b/lib/shimmer/tasks/db.rake
@@ -25,11 +25,11 @@ namespace :db do
 
   desc "Downloads the app assets from Heroku to directory `storage`."
   task pull_assets: :environment do
-    unless system('which aws > /dev/null 2>&1')
-      if system('which brew > /dev/null 2>&1')
-        puts 'AWS CLI is not installed. You can install it using Homebrew with the command: brew install awscli'
+    unless system("which aws > /dev/null 2>&1")
+      if system("which brew > /dev/null 2>&1")
+        puts "AWS CLI is not installed. You can install it using Homebrew with the command: brew install awscli"
       else
-        puts 'AWS CLI is not installed. Please install it to continue.'
+        puts "AWS CLI is not installed. Please install it to continue."
       end
       exit(1)
     end

--- a/lib/shimmer/tasks/db.rake
+++ b/lib/shimmer/tasks/db.rake
@@ -7,7 +7,7 @@ namespace :db do
       if system("which brew > /dev/null 2>&1")
         puts "Heroku CLI is not installed. Please install it with the command: brew tap heroku/brew && brew install heroku"
       else
-        puts "AWS CLI is not installed. Please install it to continue."
+        puts "Heroku CLI is not installed. Please install it to continue."
       end
       exit(1)
     end

--- a/lib/shimmer/tasks/db.rake
+++ b/lib/shimmer/tasks/db.rake
@@ -3,6 +3,11 @@
 namespace :db do
   desc "Downloads the app database from Heroku and imports it to the local database"
   task pull_data: :environment do
+    unless system("heroku apps:info")
+      puts "Heroku remote is not set. Please add a Heroku remote with `heroku git:remote -a your-app-name`."
+      next
+    end
+
     config = if Rails.version.to_f >= 7
       ActiveRecord::Base.connection_db_config.configuration_hash.with_indifferent_access
     else
@@ -20,6 +25,15 @@ namespace :db do
 
   desc "Downloads the app assets from Heroku to directory `storage`."
   task pull_assets: :environment do
+    unless system('which aws > /dev/null 2>&1')
+      if system('which brew > /dev/null 2>&1')
+        puts 'AWS CLI is not installed. You can install it using Homebrew with the command: brew install awscli'
+      else
+        puts 'AWS CLI is not installed. Please install it to continue.'
+      end
+      exit(1)
+    end
+
     config = JSON.parse(`heroku config --json`)
     ENV["AWS_DEFAULT_REGION"] = config.fetch("AWS_REGION")
     bucket = config.fetch("AWS_BUCKET")


### PR DESCRIPTION
Both @Adeynack and I ran into an issue when trying to run `rails db:pull` without having the heroku remote added that we ran into the following error which isn't very descriptive to the issue that the app isn't linked properly. I have added a guard statement for both **pull_data** and **pull_assets** db tasks that provide instructions to install **aws-cli** and link the repo to **heroku** if it's missing.

```sh
❯ rails db:pull
Dropped database 'copacoupona_development'
Dropped database 'copacoupona_test'
heroku pg:pull DATABASE_URL copacoupona_development
 ›   Error: Missing required flag:
 ›    -a, --app APP  app to run command against
 ›   See more help with --help
bin/rails aborted!
Command failed with status (2): [heroku pg:pull DATABASE_URL copacoupona_deve...]

Tasks: TOP => db:pull => db:pull_data
(See full trace by running task with --trace)
```