### PR TITLE
add include_all to respond_to_missing

### DIFF
--- a/lib/shimmer/utils/config.rb
+++ b/lib/shimmer/utils/config.rb
@@ -24,7 +24,7 @@ module Shimmer
       coerce value, type
     end
 
-    def respond_to_missing?(method_name)
+    def respond_to_missing?(method_name, include_all)
       true
     end
 


### PR DESCRIPTION
This PR fixes an argument error in `config.rb`, `:respond_to_missing?` takes two arguments instead of one. 
https://ruby-doc.org/3.2.2/Object.html#method-i-respond_to-3F

This came up while trying to stub the Config object in rspec.