### PR TITLE
Don't blow up in FileController when invalid or deleted files are requested

### DIFF
--- a/lib/shimmer/controllers/files_controller.rb
+++ b/lib/shimmer/controllers/files_controller.rb
@@ -10,6 +10,8 @@ module Shimmer
         filename: proxy.filename.to_s,
         type: proxy.content_type,
         disposition: "inline"
+    rescue ActiveRecord::RecordNotFound, ActiveStorage::FileNotFoundError
+      head :not_found
     end
   end
 end

--- a/spec/system/files_spec.rb
+++ b/spec/system/files_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "system_helper"
+
+RSpec.describe "Files" do
+  fixtures :all
+
+  it "doesn't blow up when invalid id is passed" do
+    visit file_path("invalid")
+
+    expect(page).to have_http_status(:not_found)
+  end
+
+  it "doesn't blow up when file was deleted on S3" do
+    id = Shimmer::FileProxy.message_verifier.generate(["123", nil])
+    service_double = double
+    allow(service_double).to receive(:download).with("key").and_raise(ActiveStorage::FileNotFoundError)
+    deleted_file = instance_double(ActiveStorage::Blob, service: service_double, key: "key")
+    allow(ActiveStorage::Blob).to receive(:find).with("123").and_return(deleted_file)
+
+    visit file_path(id)
+
+    expect(page).to have_http_status(:not_found)
+  end
+end


### PR DESCRIPTION
Hello! 

Love the project, really helpful!

I noticed that when using the `FileController`, it would not handle missing assets. Our Sentry instance receives a lot of `ActiveStorage::FileNotFoundError`s for assets that are removed from our S3 bucket.

It also blows up with `ActiveRecord::RecordNotFound` when requesting an invalid ID.

My suggestion is to catch these two cases and return a 404 instead.

Thank you for the consideration!