### PR TITLE
add config helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,45 @@ Replace `GOOGLE_TAG_MANAGER_ID` with your Google Tag Manager ID or `GOOGLE_ANALY
 
 **User Consent**: `Shimmer::Consent` provides a [stimulus controller](src/controllers/consent.ts) for creating a cookie banner. When the 'statistic' option is submitted to the controller, the necessary tracking scripts are added to the page's head.
 
+### Configuration
+
+Shimmer provides a Config object which can be used to access encrypted credentials and environment variables. (YAML nesting of keys is not supported)
+
+**Basic Usage**
+Retrieve a configuration value directly using the name of the key. For example, to access the SECRET_KEY configuration:
+```ruby
+Config.secret_key
+```
+
+**Required Configuration Values**
+Append an exclamation mark (!) to enforce the presence of a configuration key. If the key is missing, a `Shimmer::Config::MissingConfigError` is raised.
+```ruby
+Config.secret_key!
+```
+
+**Boolean Configuration Values**
+Append a question mark (?) for boolean type coercion. This is useful for feature flags or boolean settings.
+```ruby
+Config.secret_key?
+```
+
+**Default Values**
+Specify a default value using the :default option. This value is returned when the specified key is not found in the environment or credentials.
+```ruby
+Config.secret_key(default: true)
+```
+
+**Stubbing Configuration in Tests**
+Shimmer includes a helper module for conveniently stubbing configuration values in tests, particularly useful in RSpec.
+
+**Example Usage:**
+Stub one or multiple configuration keys using the `stub_config` method:
+```ruby
+stub_config secret_key: "secret_key", secret_key_2: "secret_key_2"
+```
+This approach allows you to simulate various configurations without altering/needing the actual environment variables or encrypted credentials.
+
+
 ## Installation
 
 Add this line to your application's Gemfile:
@@ -347,6 +386,8 @@ import { application } from "controllers/application";
 
 start({ application });
 ```
+
+
 
 ## Testing & Demo
 

--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ Config.secret_key!
 ```
 
 **Boolean Configuration Values**
-Append a question mark (?) for boolean type coercion. This is useful for feature flags or boolean settings.
+Append a question mark (`?`) for boolean type coercion. This is useful for feature flags or boolean settings.
 ```ruby
 Config.sparkle
 # => "no" (or "n", "0", "false")

--- a/README.md
+++ b/README.md
@@ -330,7 +330,15 @@ Config.secret_key!
 **Boolean Configuration Values**
 Append a question mark (?) for boolean type coercion. This is useful for feature flags or boolean settings.
 ```ruby
-Config.secret_key?
+Config.sparkle
+# => "no" (or "n", "0", "false")
+Config.sparkle?
+# => false
+
+Config.shimmer
+# => "yes" (or anything else)
+Config.shimmer?
+# => true
 ```
 
 **Default Values**

--- a/lib/shimmer/utils/config.rb
+++ b/lib/shimmer/utils/config.rb
@@ -28,8 +28,6 @@ module Shimmer
       true
     end
 
-    private
-
     def coerce(value, type)
       return !value.downcase.in?(["n", "0", "no", "false"]) if type == :bool && value.is_a?(String)
 

--- a/spec/helpers/config_helper_spec.rb
+++ b/spec/helpers/config_helper_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ConfigHelper do
+  describe "#stub_config" do
+    it "stubs a method to return a specified value" do
+      stub_config(test_config: "value")
+
+      expect(Config.test_config).to eq "value"
+    end
+
+    it "stubs a method to return nil" do
+      stub_config(test_config: nil)
+
+      expect(Config.test_config).to be_nil
+    end
+
+    it "stubs a method with a ! suffix to raise an error when value is nil" do
+      stub_config(test_config: nil)
+
+      expect { Config.test_config! }.to raise_error(Shimmer::Config::MissingConfigError)
+    end
+
+    it "does not raise an error for ! method when value is present" do
+      stub_config(test_config: "some value")
+
+      expect { Config.test_config! }.not_to raise_error
+    end
+
+    it "stubs a method with a ? suffix to return a boolean value" do
+      stub_config(test_config: true)
+
+      expect(Config.test_config?).to be true
+    end
+
+    it "returns default value when main config value is nil" do
+      stub_config(test_config: nil)
+
+      expect(Config.test_config).to be_nil
+      expect(Config.test_config(default: "default_value")).to eq "default_value"
+    end
+
+    it "correctly coerces string 'yes' to true" do
+      stub_config(test_config: "yes")
+
+      expect(Config.test_config?).to be true
+    end
+
+    it "correctly coerces string 'no' to false" do
+      stub_config(test_config: "no")
+
+      expect(Config.test_config?).to be false
+    end
+
+    it "correctly coerces numeric 1 to true" do
+      stub_config(test_config: 1)
+
+      expect(Config.test_config?).to be true
+    end
+
+    it "correctly coerces numeric 0 to false" do
+      stub_config(test_config: 0)
+
+      expect(Config.test_config?).to be false
+    end
+
+    it "treats nil as false when coerced to boolean" do
+      stub_config test_config: nil
+
+      expect(Config.test_config?).to be false
+    end
+
+    it "handles mixed-case boolean strings correctly" do
+      stub_config test_config: "TrUe"
+
+      expect(Config.test_config?).to be true
+    end
+  end
+end

--- a/spec/helpers/config_helper_spec.rb
+++ b/spec/helpers/config_helper_spec.rb
@@ -54,19 +54,13 @@ RSpec.describe ConfigHelper do
     end
 
     it "correctly coerces numeric 1 to true" do
-      stub_config(test_config: 1)
+      stub_config(test_config: "1")
 
       expect(Config.test_config?).to be true
     end
 
     it "correctly coerces numeric 0 to false" do
-      stub_config(test_config: 0)
-
-      expect(Config.test_config?).to be false
-    end
-
-    it "treats nil as false when coerced to boolean" do
-      stub_config test_config: nil
+      stub_config(test_config: "0")
 
       expect(Config.test_config?).to be false
     end

--- a/spec/support/system/config_helper.rb
+++ b/spec/support/system/config_helper.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module ConfigHelper
+  def stub_config(**options)
+    options.each do |method_name, return_value|
+      method_name = method_name.to_s.downcase
+
+      allow(Config).to receive(method_name).with(any_args) do |*args|
+        args = args.first || {}
+        return_value.nil? ? args[:default] : return_value
+      end
+
+      allow(Config).to receive(:"#{method_name}?").and_return(coerce_to_boolean(return_value))
+
+      allow(Config).to receive(:"#{method_name}!").with(any_args) do
+        raise Shimmer::Config::MissingConfigError if return_value.nil?
+
+        return_value
+      end
+    end
+  end
+
+  private
+
+  def coerce_to_boolean(value)
+    return false if value.nil? # Handle nil values
+
+    if value.is_a?(String)
+      !value.downcase.in?(["n", "0", "no", "false"])
+    elsif value == 0
+      false
+    elsif value == 1
+      true
+    else
+      value
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.include ConfigHelper
+end

--- a/spec/support/system/config_helper.rb
+++ b/spec/support/system/config_helper.rb
@@ -10,29 +10,15 @@ module ConfigHelper
         return_value.nil? ? args[:default] : return_value
       end
 
-      allow(Config).to receive(:"#{method_name}?").and_return(coerce_to_boolean(return_value))
+      # Use coerce method from Shimmer::Config
+      coerced_value = Shimmer::Config.instance.coerce(return_value, :bool)
+      allow(Config).to receive(:"#{method_name}?").and_return(coerced_value)
 
       allow(Config).to receive(:"#{method_name}!").with(any_args) do
         raise Shimmer::Config::MissingConfigError if return_value.nil?
 
         return_value
       end
-    end
-  end
-
-  private
-
-  def coerce_to_boolean(value)
-    return false if value.nil? # Handle nil values
-
-    if value.is_a?(String)
-      !value.downcase.in?(["n", "0", "no", "false"])
-    elsif value == 0
-      false
-    elsif value == 1
-      true
-    else
-      value
     end
   end
 end


### PR DESCRIPTION
This PR adds a config helper, which allows the user to stub the config object in tests and also documentation on how to use the config object.