### PR TITLE
Don't upscale FileProxy variants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,4 @@
 /dist
 /node_modules
 /yarn-error.log
-/gemfiles/*.lock
 .DS_Store

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -187,6 +187,8 @@ GEM
       racc (~> 1.4)
     nokogiri (1.14.1-x86_64-darwin)
       racc (~> 1.4)
+    nokogiri (1.14.1-x86_64-linux)
+      racc (~> 1.4)
     notiffany (0.1.3)
       nenv (~> 0.1)
       shellany (~> 0.0)
@@ -318,6 +320,7 @@ GEM
       mini_portile2 (~> 2.8.0)
     sqlite3 (1.6.0-arm64-darwin)
     sqlite3 (1.6.0-x86_64-darwin)
+    sqlite3 (1.6.0-x86_64-linux)
     standard (1.28.0)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.0)
@@ -360,6 +363,7 @@ PLATFORMS
   arm64-darwin-22
   ruby
   x86_64-darwin-22
+  x86_64-linux
 
 DEPENDENCIES
   annotate

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -179,6 +179,8 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.8)
+    nokogiri (1.14.1-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.14.1-x86_64-darwin)
       racc (~> 1.4)
     notiffany (0.1.3)
@@ -308,6 +310,7 @@ GEM
       actionpack (>= 3.1)
       railties (>= 3.1)
       slim (>= 3.0, < 5.0)
+    sqlite3 (1.6.0-arm64-darwin)
     sqlite3 (1.6.0-x86_64-darwin)
     standard (1.28.0)
       language_server-protocol (~> 3.17.0.2)
@@ -348,6 +351,7 @@ GEM
     zeitwerk (2.6.6)
 
 PLATFORMS
+  arm64-darwin-22
   x86_64-darwin-22
 
 DEPENDENCIES

--- a/gemfiles/Gemfile-rails-7-0
+++ b/gemfiles/Gemfile-rails-7-0
@@ -7,7 +7,7 @@ gemspec path: ".."
 
 gem "rails", "~> 7.0.0"
 gem "propshaft"
-gem "sqlite3"
+gem "sqlite3", "~> 1.6"
 gem "puma"
 gem "jsbundling-rails"
 gem "turbo-rails"

--- a/gemfiles/Gemfile-rails-7-0.lock
+++ b/gemfiles/Gemfile-rails-7-0.lock
@@ -1,5 +1,5 @@
 PATH
-  remote: .
+  remote: ..
   specs:
     shimmer (0.0.1)
 
@@ -166,6 +166,7 @@ GEM
     method_source (1.0.0)
     mini_magick (4.12.0)
     mini_mime (1.1.2)
+    mini_portile2 (2.8.6)
     minitest (5.17.0)
     msgpack (1.6.0)
     nenv (0.3.0)
@@ -179,9 +180,14 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.8)
+    nokogiri (1.14.1)
+      mini_portile2 (~> 2.8.0)
+      racc (~> 1.4)
     nokogiri (1.14.1-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.14.1-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.14.1-x86_64-linux)
       racc (~> 1.4)
     notiffany (0.1.3)
       nenv (~> 0.1)
@@ -310,8 +316,11 @@ GEM
       actionpack (>= 3.1)
       railties (>= 3.1)
       slim (>= 3.0, < 5.0)
+    sqlite3 (1.6.0)
+      mini_portile2 (~> 2.8.0)
     sqlite3 (1.6.0-arm64-darwin)
     sqlite3 (1.6.0-x86_64-darwin)
+    sqlite3 (1.6.0-x86_64-linux)
     standard (1.28.0)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.0)
@@ -352,7 +361,9 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  ruby
   x86_64-darwin-22
+  x86_64-linux
 
 DEPENDENCIES
   annotate
@@ -377,7 +388,7 @@ DEPENDENCIES
   pry-rails
   puma
   rack_session_access
-  rails
+  rails (~> 7.0.0)
   rake
   rspec-rails
   rspec-retry
@@ -388,7 +399,7 @@ DEPENDENCIES
   rubocop-rspec
   shimmer!
   slim-rails
-  sqlite3
+  sqlite3 (~> 1.6)
   standard
   stimulus-rails
   turbo-rails

--- a/gemfiles/Gemfile-rails-7-0.lock
+++ b/gemfiles/Gemfile-rails-7-0.lock
@@ -166,7 +166,6 @@ GEM
     method_source (1.0.0)
     mini_magick (4.12.0)
     mini_mime (1.1.2)
-    mini_portile2 (2.8.6)
     minitest (5.17.0)
     msgpack (1.6.0)
     nenv (0.3.0)
@@ -180,9 +179,6 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.8)
-    nokogiri (1.14.1)
-      mini_portile2 (~> 2.8.0)
-      racc (~> 1.4)
     nokogiri (1.14.1-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.14.1-x86_64-darwin)
@@ -314,8 +310,6 @@ GEM
       actionpack (>= 3.1)
       railties (>= 3.1)
       slim (>= 3.0, < 5.0)
-    sqlite3 (1.6.0)
-      mini_portile2 (~> 2.8.0)
     sqlite3 (1.6.0-arm64-darwin)
     sqlite3 (1.6.0-x86_64-darwin)
     standard (1.28.0)
@@ -358,7 +352,6 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
-  ruby
   x86_64-darwin-22
 
 DEPENDENCIES

--- a/lib/shimmer/utils/file_proxy.rb
+++ b/lib/shimmer/utils/file_proxy.rb
@@ -20,7 +20,7 @@ module Shimmer
         resize = if height
           "#{width}x#{height}>"
         else
-          "#{width}x"
+          "#{width}x>"
         end
       end
       @resize = resize

--- a/spec/rails_app/Gemfile.lock
+++ b/spec/rails_app/Gemfile.lock
@@ -135,6 +135,9 @@ GEM
       rspec (>= 2.99.0, < 4.0)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
+    image_processing (1.12.2)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
     io-console (0.6.0)
     irb (1.6.2)
       reline (>= 0.3.0)
@@ -144,6 +147,8 @@ GEM
     jsbundling-rails (1.1.1)
       railties (>= 6.0.0)
     json (2.6.3)
+    language_server-protocol (3.17.0.3)
+    lint_roller (1.0.0)
     listen (3.8.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -151,7 +156,7 @@ GEM
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     lumberjack (1.2.8)
-    mail (2.8.0.1)
+    mail (2.8.1)
       mini_mime (>= 0.1.1)
       net-imap
       net-pop
@@ -159,6 +164,7 @@ GEM
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
+    mini_magick (4.12.0)
     mini_mime (1.1.2)
     minitest (5.17.0)
     msgpack (1.6.0)
@@ -173,13 +179,15 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.8)
+    nokogiri (1.14.1-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.14.1-x86_64-darwin)
       racc (~> 1.4)
     notiffany (0.1.3)
       nenv (~> 0.1)
       shellany (~> 0.0)
-    parallel (1.22.1)
-    parser (3.2.0.0)
+    parallel (1.23.0)
+    parser (3.2.2.1)
       ast (~> 2.4.1)
     propshaft (0.6.4)
       actionpack (>= 7.0.0)
@@ -198,7 +206,7 @@ GEM
     pry-rails (0.3.9)
       pry (>= 0.10.4)
     public_suffix (5.0.1)
-    puma (5.6.5)
+    puma (6.0.2)
       nio4r (~> 2.0)
     racc (1.6.2)
     rack (2.2.6.2)
@@ -238,7 +246,7 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    regexp_parser (2.6.2)
+    regexp_parser (2.8.0)
     reline (0.3.2)
       io-console (~> 0.5)
     rexml (3.2.5)
@@ -246,7 +254,7 @@ GEM
       rspec-core (~> 3.12.0)
       rspec-expectations (~> 3.12.0)
       rspec-mocks (~> 3.12.0)
-    rspec-core (3.12.0)
+    rspec-core (3.12.1)
       rspec-support (~> 3.12.0)
     rspec-expectations (3.12.2)
       diff-lcs (>= 1.2.0, < 2.0)
@@ -265,21 +273,21 @@ GEM
     rspec-retry (0.6.2)
       rspec-core (> 3.3)
     rspec-support (3.12.0)
-    rubocop (1.44.1)
+    rubocop (1.50.2)
       json (~> 2.3)
       parallel (~> 1.10)
       parser (>= 3.2.0.0)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.24.1, < 2.0)
+      rubocop-ast (>= 1.28.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.24.1)
-      parser (>= 3.1.1.0)
-    rubocop-capybara (2.17.0)
+    rubocop-ast (1.28.0)
+      parser (>= 3.2.1.0)
+    rubocop-capybara (2.18.0)
       rubocop (~> 1.41)
-    rubocop-performance (1.15.2)
+    rubocop-performance (1.16.0)
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
     rubocop-rails (2.17.4)
@@ -288,10 +296,12 @@ GEM
       rubocop (>= 1.33.0, < 2.0)
     rubocop-rake (0.6.0)
       rubocop (~> 1.0)
-    rubocop-rspec (2.18.1)
+    rubocop-rspec (2.20.0)
       rubocop (~> 1.33)
       rubocop-capybara (~> 2.17)
-    ruby-progressbar (1.11.0)
+    ruby-progressbar (1.13.0)
+    ruby-vips (2.1.4)
+      ffi (~> 1.12)
     shellany (0.0.1)
     slim (4.1.0)
       temple (>= 0.7.6, < 0.9)
@@ -300,7 +310,19 @@ GEM
       actionpack (>= 3.1)
       railties (>= 3.1)
       slim (>= 3.0, < 5.0)
+    sqlite3 (1.6.0-arm64-darwin)
     sqlite3 (1.6.0-x86_64-darwin)
+    standard (1.28.0)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.0)
+      rubocop (~> 1.50.2)
+      standard-custom (~> 1.0.0)
+      standard-performance (~> 1.0.1)
+    standard-custom (1.0.0)
+      lint_roller (~> 1.0)
+    standard-performance (1.0.1)
+      lint_roller (~> 1.0)
+      rubocop-performance (~> 1.16.0)
     stimulus-rails (1.2.1)
       railties (>= 6.0.0)
     temple (0.8.2)
@@ -319,18 +341,18 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webrick (1.7.0)
+    webrick (1.8.1)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
+    yard (0.9.26)
     zeitwerk (2.6.6)
 
 PLATFORMS
-  x86_64-darwin-21
+  arm64-darwin-22
+  x86_64-darwin-22
 
 DEPENDENCIES
   annotate
@@ -344,16 +366,19 @@ DEPENDENCIES
   dotenv-rails
   guard
   guard-rspec
+  image_processing
   jbuilder
   jsbundling-rails
+  mini_magick
   propshaft
   pry
   pry-byebug
   pry-doc
   pry-rails
-  puma (~> 5.0)
+  puma
   rack_session_access
-  rails (~> 7.0.4)
+  rails
+  rake
   rspec-rails
   rspec-retry
   rubocop
@@ -363,13 +388,11 @@ DEPENDENCIES
   rubocop-rspec
   shimmer!
   slim-rails
-  sqlite3 (~> 1.4)
+  sqlite3
+  standard
   stimulus-rails
   turbo-rails
   web-console
 
-RUBY VERSION
-   ruby 3.0.3p157
-
 BUNDLED WITH
-   2.3.26
+   2.4.9

--- a/spec/utils/shimmer/file_proxy_spec.rb
+++ b/spec/utils/shimmer/file_proxy_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Shimmer::FileProxy do
+  let(:blob) {
+    ActiveStorage::Blob.create_and_upload!(
+      io: File.open(Rails.root.join("spec/fixtures/files/nerdgeschoss.jpg")),
+      filename: "example",
+      content_type: "image/jpeg"
+    )
+  }
+
+  describe "#variant" do
+    it "returns the blob if no resize requested" do
+      variant = Shimmer::FileProxy.new(blob_id: blob.id).variant
+
+      expect(variant).to eq(blob)
+    end
+
+    context "when requesting different size" do
+      it "scales the image down" do
+        variant = Shimmer::FileProxy.new(blob_id: blob.id, width: 100, height: 200).variant
+
+        expect(dimensions(variant.processed.image.blob)).to eq({width: 100, height: 35})
+      end
+
+      it "does not scale the image up" do
+        variant = Shimmer::FileProxy.new(blob_id: blob.id, width: 1000).variant
+
+        original_dimensions = dimensions(blob)
+        new_dimensions = dimensions(variant.processed.image.blob)
+
+        expect(new_dimensions).to eq(original_dimensions)
+      end
+    end
+  end
+
+  def dimensions(blob)
+    ActiveStorage::Analyzer::ImageAnalyzer::ImageMagick.new(blob).metadata
+  end
+end


### PR DESCRIPTION
At the moment, we resize images to the requested width even if they are smaller – but only if we don't set a height. This looks like an oversight. We probably always want the smallest possible size, I don't see a reason why we would want to scale up.