### PR TITLE
BUG: Cast FileProxy sizes to integer

### DIFF
--- a/lib/shimmer/utils/file_proxy.rb
+++ b/lib/shimmer/utils/file_proxy.rb
@@ -39,7 +39,7 @@ module Shimmer
 
     def initialize(blob_id:, width: nil, height: nil)
       @blob_id = blob_id
-      @resize = [width, height] if width || height
+      @resize = [width&.to_i, height&.to_i] if width || height
     end
 
     def path

--- a/spec/utils/shimmer/file_proxy_spec.rb
+++ b/spec/utils/shimmer/file_proxy_spec.rb
@@ -43,6 +43,14 @@ RSpec.describe Shimmer::FileProxy do
       expect(dimensions(variant.processed.image.blob)).to eq({width: 290, height: 100})
     end
 
+    it "works if passing width or height as string" do
+      proxy = Shimmer::FileProxy.new(blob_id: blob.id, width: "290", height: "100")
+      id = proxy.send(:id)
+      variant = Shimmer::FileProxy.restore(id).variant
+
+      expect(dimensions(variant.processed.image.blob)).to eq({width: 290, height: 100})
+    end
+
     it "works if not resizing" do
       proxy = Shimmer::FileProxy.new(blob_id: blob.id)
       id = proxy.send(:id)


### PR DESCRIPTION
If we don't do this and accidentally pass a string like `"200"`, it will error with:

```
TypeError:
  no implicit conversion of String into Integer
```
