### PR TITLE
Improve `enfore_modal` method and rescue from it

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,12 @@ a href=popover_path(new_post_path, placement: :left)
 
 This will request `new_post_path` and display it left of the anchor thanks to PopperJS.
 
+> [!TIP]
+> If you want to make sure that your modal content is only available if requested through Shimmer, you can use the built in `enfore_modal` method as a `before_action`. It will return a _422 Unprocessable Content_ status if users (or bots) access the page directly.
+> ```rb
+> before_action :enforce_modal, only: [:popover]
+> ```
+
 ### Remote Navigation
 
 Remote navigation takes Hotwire to the next level with built-in navigation actions, integrated with modals and popovers.

--- a/spec/rails_app/app/controllers/posts_controller.rb
+++ b/spec/rails_app/app/controllers/posts_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class PostsController < ApplicationController
+  before_action :enforce_modal, only: [:modal]
+
   def index
     @posts = Post.all
   end
@@ -16,6 +18,9 @@ class PostsController < ApplicationController
     else
       render :new
     end
+  end
+
+  def modal
   end
 
   private

--- a/spec/rails_app/config/routes.rb
+++ b/spec/rails_app/config/routes.rb
@@ -2,7 +2,11 @@
 
 Rails.application.routes.draw do
   resources :files, only: :show, controller: "shimmer/files"
-  resources :posts
+  resources :posts do
+    collection do
+      get :modal
+    end
+  end
 
   get "styleguide", to: "pages#styleguide"
   root "posts#index"


### PR DESCRIPTION
At the moment, `enforce_modal` raises an error. If you have a lot of modals that are perused by a lot of bots, this can quickly add up to a lot of errors in your error monitoring service.

A user could catch these via `rescue_from`, but since we're so nice, let's do it for them and return a 422 Unprocessable Error instead.