### PR TITLE
Destroy modals before leaving

### DIFF
--- a/spec/rails_app/app/controllers/posts_controller.rb
+++ b/spec/rails_app/app/controllers/posts_controller.rb
@@ -7,6 +7,10 @@ class PostsController < ApplicationController
     @posts = Post.all
   end
 
+  def show
+    @post = Post.find(params[:id])
+  end
+
   def new
     @post = Post.new
   end

--- a/spec/rails_app/app/views/posts/new.html.slim
+++ b/spec/rails_app/app/views/posts/new.html.slim
@@ -6,3 +6,5 @@ h1 Compose Post
   = f.input :image, as: :image, placeholder: "Image of the post"
   = f.submit "Save"
   = link_to "Cancel", close_modal_path
+
+= link_to "Something completely different", other_posts_path

--- a/spec/rails_app/app/views/posts/other.html.slim
+++ b/spec/rails_app/app/views/posts/other.html.slim
@@ -1,0 +1,1 @@
+h1 Something completely different!

--- a/spec/rails_app/config/routes.rb
+++ b/spec/rails_app/config/routes.rb
@@ -6,6 +6,8 @@ Rails.application.routes.draw do
     collection do
       get :modal
     end
+
+    get :other, on: :collection
   end
 
   get "styleguide", to: "pages#styleguide"

--- a/src/modal.ts
+++ b/src/modal.ts
@@ -12,6 +12,7 @@ export class ModalPresenter {
 
   constructor() {
     document.addEventListener("turbo:load", this.prepareBlind);
+    document.addEventListener("turbo:before-cache", this.leave.bind(this));
   }
 
   async open(options: ModalOptions): Promise<void> {
@@ -38,8 +39,16 @@ export class ModalPresenter {
     document.body.classList.toggle("modal-open", open);
   }
 
+  private leave(): void {
+    Object.values(this.modals).map((e) => e.destroy());
+    this.modals = {};
+    this.updateBlindStatus();
+  }
+
   private prepareBlind: () => void = () => {
-    createElement(document.body, "modal-blind");
+    if (!document.querySelector("body > .modal-blind")) {
+      createElement(document.body, "modal-blind");
+    }
   };
 }
 
@@ -82,7 +91,11 @@ export class Modal {
     }
     root.classList.remove("modal--open");
     await wait(1);
-    root.remove();
+    this.destroy();
+  }
+
+  destroy(): void {
+    this.root?.remove();
     this.root = undefined;
   }
 }


### PR DESCRIPTION
The current modal implementation has two bugs. They both surface when you …

1. Open a modal
2. Navigate away (e.g. with a link inside the modal)
3. Go back (e.g. with the browser's back button)

The two bugs are:

1. Shimmer will add a new `.modal-blind` every time, making the blind continuously darker
2. The "close" click handler will not be added again, making it impossible to close the modal

This is in Recordsale when trying to add an album to my wantlist even though I'm not logged in, then clicking the back button:

<img width="1408" alt="Screenshot 2024-12-18 at 17 38 48" src="https://github.com/user-attachments/assets/fb44bf65-0616-4e32-8045-a877a12cd459" />

To solve this, I added code to immediately destroy all open modals. I thought it's probably not worth writing a bunch of code to try and "rehydrate" the modals on back navigation. I also added a check to only contain a new `.modal-blind` if we don't already have one.

---

I decided on this way to keep the changes and the chance for breakage minimal. If we want to keep modals open when coming back, I'd say we should maybe migrate modals to Stimulus, so Stimulus can handle all the event handlers for us.