### PR TITLE
Bug: Set consent cookie on the root path

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -61,5 +61,5 @@ export function getCookie(key: string): string | null {
 export function setCookie(key: string, value: string): void {
   const date = new Date();
   date.setTime(date.getTime() + 365 * 24 * 60 * 60 * 1000);
-  document.cookie = `${key}=${value}; expires=${date.toUTCString()}`;
+  document.cookie = `${key}=${value}; path=/; expires=${date.toUTCString()}`;
 }


### PR DESCRIPTION
At the moment, when consenting to cookies, we're (implicitly) setting the cookie on the path the user is currently on.

This can be confusing when navigating, because the cookie banner will pop up again and again.

In this tiny PR, I added the classic `path=/;` part to the cookie definition, so that we always set it on the root path.