### PR TITLE
Transform images to WebP automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,8 @@ Shimmer will only ever scale your images down, not up.
 
 The URL of the image will point to the Rails app, where it will be generated on the fly. You should cache these routes with a CDN like Cloudflare.
 
+Shimmer will also return your images as WebP if the browser sends `image/webp` in the `HTTP_ACCEPT` header, and set the `Vary: Accept` header in the response. Make sure to enable support for this in your CDN.
+
 This is in contrast to ActiveStorage variants, where the transformation happens when the URL for the image is built. This can slow down rendering or even prevent HTML to be generated if just one image can't be resized. With Shimmer, only the broken image will be broken.
 
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Then, if there are specific cops you want to use in the specific project you are
 
 `ActiveStorage` is great, but serving of files, especially behind a CDN, can be complicated to get right. Shimmer has your back.
 
-It overrides `image_tag` and automatically resizes your image and creates a static, cacheable URL.
+It overrides `image_tag` and automatically resizes your image, converts it to WebP, and creates a static, cacheable URL.
 
 ```ruby
 # use an image tag
@@ -158,8 +158,6 @@ image_file_url(user.avatar, width: 300, height: 400)
 Shimmer will only ever scale your images down, not up.
 
 The URL of the image will point to the Rails app, where it will be generated on the fly. You should cache these routes with a CDN like Cloudflare.
-
-Shimmer will also return your images as WebP if the browser sends `image/webp` in the `HTTP_ACCEPT` header, and set the `Vary: Accept` header in the response. Make sure to enable support for this in your CDN.
 
 This is in contrast to ActiveStorage variants, where the transformation happens when the URL for the image is built. This can slow down rendering or even prevent HTML to be generated if just one image can't be resized. With Shimmer, only the broken image will be broken.
 

--- a/lib/shimmer/controllers/files_controller.rb
+++ b/lib/shimmer/controllers/files_controller.rb
@@ -7,7 +7,7 @@ module Shimmer
       response.headers["Vary"] = "Accept"
       request.session_options[:skip] = true # prevents a session cookie from being set (would prevent caching on CDNs)
 
-      proxy = FileProxy.restore(params.require(:id), format: override_format)
+      proxy = FileProxy.restore(params.require(:id))
       send_data(
         proxy.file,
         filename: proxy.filename.to_s,
@@ -16,17 +16,6 @@ module Shimmer
       )
     rescue ActiveRecord::RecordNotFound, ActiveStorage::FileNotFoundError
       head :not_found
-    end
-
-    private
-
-    def override_format
-      accepted_formats = request.headers["HTTP_ACCEPT"].to_s
-
-      return "webp" if accepted_formats.include?("image/webp")
-      return "webp" if request.path.ends_with?(".webp")
-
-      nil
     end
   end
 end

--- a/lib/shimmer/controllers/files_controller.rb
+++ b/lib/shimmer/controllers/files_controller.rb
@@ -4,7 +4,6 @@ module Shimmer
   class FilesController < ActionController::Base
     def show
       expires_in 1.year, public: true
-      response.headers["Vary"] = "Accept"
       request.session_options[:skip] = true # prevents a session cookie from being set (would prevent caching on CDNs)
 
       proxy = FileProxy.restore(params.require(:id))

--- a/lib/shimmer/controllers/files_controller.rb
+++ b/lib/shimmer/controllers/files_controller.rb
@@ -4,14 +4,29 @@ module Shimmer
   class FilesController < ActionController::Base
     def show
       expires_in 1.year, public: true
+      response.headers["Vary"] = "Accept"
       request.session_options[:skip] = true # prevents a session cookie from being set (would prevent caching on CDNs)
-      proxy = FileProxy.restore(params.require(:id))
-      send_data proxy.file,
+
+      proxy = FileProxy.restore(params.require(:id), format: override_format)
+      send_data(
+        proxy.file,
         filename: proxy.filename.to_s,
         type: proxy.content_type,
         disposition: "inline"
+      )
     rescue ActiveRecord::RecordNotFound, ActiveStorage::FileNotFoundError
       head :not_found
+    end
+
+    private
+
+    def override_format
+      accepted_formats = request.headers["HTTP_ACCEPT"].to_s
+
+      return "webp" if accepted_formats.include?("image/webp")
+      return "webp" if request.path.ends_with?(".webp")
+
+      nil
     end
   end
 end

--- a/lib/shimmer/utils/file_helper.rb
+++ b/lib/shimmer/utils/file_helper.rb
@@ -19,27 +19,31 @@ module Shimmer
         attachment = source
         width = options[:width]
         height = options[:height]
-        source = image_file_path(source, width: width, height: height)
+        format = options[:format]
+        source = image_file_path(source, width: width, height: height, format: format)
         options[:loading] ||= :lazy
-        options[:srcset] = "#{source} 1x, #{image_file_path(attachment, width: width.to_i * 2, height: height ? height.to_i * 2 : nil)} 2x" if options[:width].present?
+        if options[:width].present?
+          source_2x = image_file_path(attachment, width: width.to_i * 2, height: height ? height.to_i * 2 : nil, format: format)
+          options[:srcset] = "#{source} 1x, #{source_2x} 2x"
+        end
       end
       super(source, options)
     end
 
-    def image_file_path(source, width: nil, height: nil)
-      image_file_proxy(source, width: width, height: height, return_type: :path)
+    def image_file_path(source, **)
+      image_file_proxy(source, **, return_type: :path)
     end
 
-    def image_file_url(source, width: nil, height: nil)
-      image_file_proxy(source, width: width, height: height, return_type: :url)
+    def image_file_url(source, **)
+      image_file_proxy(source, **, return_type: :url)
     end
 
-    def image_file_proxy(source, width: nil, height: nil, return_type: nil)
+    def image_file_proxy(source, width: nil, height: nil, format: nil, return_type: nil)
       return if source.blank?
       return source if source.is_a?(String)
 
       blob = source.try(:blob) || source
-      proxy = Shimmer::FileProxy.new(blob_id: blob.id, width: width, height: height)
+      proxy = Shimmer::FileProxy.new(blob_id: blob.id, width: width, height: height, format: format)
       case return_type
       when nil
         proxy

--- a/lib/shimmer/utils/file_helper.rb
+++ b/lib/shimmer/utils/file_helper.rb
@@ -15,7 +15,10 @@ module Shimmer
     def image_tag(source, **options)
       return nil if source.blank?
 
-      if source.is_a?(ActiveStorage::Variant) || source.is_a?(ActiveStorage::Attached) || source.is_a?(ActiveStorage::Attachment) || source.is_a?(ActionText::Attachment)
+      if source.is_a?(ActiveStorage::Variant) ||
+          source.is_a?(ActiveStorage::Attached) ||
+          source.is_a?(ActiveStorage::Attachment) ||
+          (Object.const_defined?("ActionText::Attachment") && source.is_a?(ActionText::Attachment))
         attachment = source
         width = options[:width]
         height = options[:height]
@@ -27,6 +30,7 @@ module Shimmer
           options[:srcset] = "#{source} 1x, #{source_2x} 2x"
         end
       end
+
       super(source, options)
     end
 

--- a/lib/shimmer/utils/file_helper.rb
+++ b/lib/shimmer/utils/file_helper.rb
@@ -16,6 +16,7 @@ module Shimmer
       return nil if source.blank?
 
       if source.is_a?(ActiveStorage::Variant) ||
+          source.is_a?(ActiveStorage::VariantWithRecord) ||
           source.is_a?(ActiveStorage::Attached) ||
           source.is_a?(ActiveStorage::Attachment) ||
           (Object.const_defined?("ActionText::Attachment") && source.is_a?(ActionText::Attachment))

--- a/lib/shimmer/utils/file_helper.rb
+++ b/lib/shimmer/utils/file_helper.rb
@@ -23,11 +23,10 @@ module Shimmer
         attachment = source
         width = options[:width]
         height = options[:height]
-        format = options[:format]
-        source = image_file_path(source, width: width, height: height, format: format)
+        source = image_file_path(source, width: width, height: height)
         options[:loading] ||= :lazy
         if options[:width].present?
-          source_2x = image_file_path(attachment, width: width.to_i * 2, height: height ? height.to_i * 2 : nil, format: format)
+          source_2x = image_file_path(attachment, width: width.to_i * 2, height: height ? height.to_i * 2 : nil)
           options[:srcset] = "#{source} 1x, #{source_2x} 2x"
         end
       end
@@ -43,12 +42,12 @@ module Shimmer
       image_file_proxy(source, **, return_type: :url)
     end
 
-    def image_file_proxy(source, width: nil, height: nil, format: nil, return_type: nil)
+    def image_file_proxy(source, width: nil, height: nil, return_type: nil)
       return if source.blank?
       return source if source.is_a?(String)
 
       blob = source.try(:blob) || source
-      proxy = Shimmer::FileProxy.new(blob_id: blob.id, width: width, height: height, format: format)
+      proxy = Shimmer::FileProxy.new(blob_id: blob.id, width: width, height: height)
       case return_type
       when nil
         proxy

--- a/spec/rails_app/app/views/posts/index.html.slim
+++ b/spec/rails_app/app/views/posts/index.html.slim
@@ -13,9 +13,6 @@ a href=modal_path(new_post_path, size: "custom-size") Write New Post
       |> image_file_path:
       = image_file_path(post.image, width: 200)
     div
-      |> image_file_path:
-      = image_file_path(post.image, width: 200)
-    div
       |> image_file_url:
       = image_file_url(post.image, width: 200)
   h2 = post.title

--- a/spec/rails_app/app/views/posts/index.html.slim
+++ b/spec/rails_app/app/views/posts/index.html.slim
@@ -9,5 +9,15 @@ a href=modal_path(new_post_path, size: "custom-size") Write New Post
     div.stack.stack--line
       div = image_tag post.image, width: 200, loading: :lazy
       div = image_tag post.image, width: 200, loading: :eager
+      div = image_tag post.image, width: 200, format: :webp
+    div
+      |> image_file_path:
+      = image_file_path(post.image, width: 200)
+    div
+      |> image_file_path with <code>format: "webp"</code>:
+      = image_file_path(post.image, width: 200, format: "webp")
+    div
+      |> image_file_url:
+      = image_file_url(post.image, width: 200, format: "webp")
   h2 = post.title
   p = post.content

--- a/spec/rails_app/app/views/posts/index.html.slim
+++ b/spec/rails_app/app/views/posts/index.html.slim
@@ -9,15 +9,14 @@ a href=modal_path(new_post_path, size: "custom-size") Write New Post
     div.stack.stack--line
       div = image_tag post.image, width: 200, loading: :lazy
       div = image_tag post.image, width: 200, loading: :eager
-      div = image_tag post.image, width: 200, format: :webp
     div
       |> image_file_path:
       = image_file_path(post.image, width: 200)
     div
-      |> image_file_path with <code>format: "webp"</code>:
-      = image_file_path(post.image, width: 200, format: "webp")
+      |> image_file_path:
+      = image_file_path(post.image, width: 200)
     div
       |> image_file_url:
-      = image_file_url(post.image, width: 200, format: "webp")
+      = image_file_url(post.image, width: 200)
   h2 = post.title
   p = post.content

--- a/spec/rails_app/config/environments/development.rb
+++ b/spec/rails_app/config/environments/development.rb
@@ -66,4 +66,6 @@ Rails.application.configure do
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
+
+  routes.default_url_options[:host] = "localhost:3000"
 end

--- a/spec/rails_app/config/environments/test.rb
+++ b/spec/rails_app/config/environments/test.rb
@@ -59,4 +59,7 @@ Rails.application.configure do
 
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
+
+  routes.default_url_options[:locale] = :en
+  routes.default_url_options[:host] = "localhost:3000"
 end

--- a/spec/system/files_spec.rb
+++ b/spec/system/files_spec.rb
@@ -13,10 +13,7 @@ RSpec.describe "Files" do
 
   it "doesn't blow up when file was deleted on S3" do
     id = Shimmer::FileProxy.message_verifier.generate(["123", nil])
-    service_double = double
-    allow(service_double).to receive(:download).with("key").and_raise(ActiveStorage::FileNotFoundError)
-    deleted_file = instance_double(ActiveStorage::Blob, service: service_double, key: "key", representable?: true)
-    allow(ActiveStorage::Blob).to receive(:find).with("123").and_return(deleted_file)
+    allow(Shimmer::FileProxy).to receive(:restore).and_raise(ActiveStorage::FileNotFoundError)
 
     get file_path(id)
 

--- a/spec/system/files_spec.rb
+++ b/spec/system/files_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Files" do
     id = Shimmer::FileProxy.message_verifier.generate(["123", nil])
     service_double = double
     allow(service_double).to receive(:download).with("key").and_raise(ActiveStorage::FileNotFoundError)
-    deleted_file = instance_double(ActiveStorage::Blob, service: service_double, key: "key")
+    deleted_file = instance_double(ActiveStorage::Blob, service: service_double, key: "key", representable?: true)
     allow(ActiveStorage::Blob).to receive(:find).with("123").and_return(deleted_file)
 
     get file_path(id)

--- a/spec/system_helper.rb
+++ b/spec/system_helper.rb
@@ -4,7 +4,6 @@ require "rails_helper"
 require "rack_session_access/capybara"
 require "rspec/retry"
 
-Rails.application.routes.default_url_options[:locale] = :en
 
 RSpec.configure do |config|
   config.before(:each, type: :system) do

--- a/spec/system_helper.rb
+++ b/spec/system_helper.rb
@@ -4,7 +4,6 @@ require "rails_helper"
 require "rack_session_access/capybara"
 require "rspec/retry"
 
-
 RSpec.configure do |config|
   config.before(:each, type: :system) do
     driven_by Capybara.javascript_driver

--- a/spec/utils/shimmer/file_proxy_spec.rb
+++ b/spec/utils/shimmer/file_proxy_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Shimmer::FileProxy do
       expect(dimensions(variant.processed.image.blob)).to eq({width: 290, height: 100})
     end
 
-    it "accepts an image format to convert the image to" do
+    it "converts the image to webp when passing webp as format" do
       proxy = Shimmer::FileProxy.new(blob_id: blob.id)
       id = proxy.send(:id)
       variant = Shimmer::FileProxy.restore(id, format: "webp").variant

--- a/spec/utils/shimmer/file_proxy_spec.rb
+++ b/spec/utils/shimmer/file_proxy_spec.rb
@@ -51,28 +51,20 @@ RSpec.describe Shimmer::FileProxy do
       expect(dimensions(variant.processed.image.blob)).to eq({width: 290, height: 100})
     end
 
-    it "converts the image to webp when passing webp as format" do
-      proxy = Shimmer::FileProxy.new(blob_id: blob.id)
-      id = proxy.send(:id)
-      variant = Shimmer::FileProxy.restore(id, format: "webp").variant
-
-      expect(variant.content_type).to eq("image/webp")
-    end
-
     it "works if not resizing" do
       proxy = Shimmer::FileProxy.new(blob_id: blob.id)
       id = proxy.send(:id)
-      original_blob = Shimmer::FileProxy.restore(id).variant
+      variant = Shimmer::FileProxy.restore(id).variant
 
-      expect(dimensions(original_blob)).to eq({width: 559, height: 193})
+      expect(dimensions(variant.processed.image.blob)).to eq({width: 559, height: 193})
     end
   end
 
   describe "#variant" do
-    it "returns the blob if no resize requested" do
+    it "transforms to webp even if no resize requested" do
       variant = Shimmer::FileProxy.new(blob_id: blob.id).variant
 
-      expect(variant).to eq(blob)
+      expect(variant.content_type).to eq("image/webp")
     end
 
     context "when requesting different size" do

--- a/spec/utils/shimmer/file_proxy_spec.rb
+++ b/spec/utils/shimmer/file_proxy_spec.rb
@@ -51,6 +51,14 @@ RSpec.describe Shimmer::FileProxy do
       expect(dimensions(variant.processed.image.blob)).to eq({width: 290, height: 100})
     end
 
+    it "accepts an image format to convert the image to" do
+      proxy = Shimmer::FileProxy.new(blob_id: blob.id)
+      id = proxy.send(:id)
+      variant = Shimmer::FileProxy.restore(id, format: "webp").variant
+
+      expect(variant.content_type).to eq("image/webp")
+    end
+
     it "works if not resizing" do
       proxy = Shimmer::FileProxy.new(blob_id: blob.id)
       id = proxy.send(:id)


### PR DESCRIPTION
With this PR, Shimmer will also return your images as WebP if the browser sends `image/webp` in the `HTTP_ACCEPT` header, and set the `Vary: Accept` header in the response.