### PR TITLE
Speed up filter pill popovers

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,8 +76,8 @@ GEM
       minitest (>= 5.1)
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
-    addressable (2.8.7)
-      public_suffix (>= 2.0.2, < 7.0)
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
     annotate (3.2.0)
       activerecord (>= 3.2, < 8.0)
       rake (>= 10.4, < 14.0)
@@ -98,11 +98,11 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
-    capybara-playwright-driver (0.5.2)
+    capybara-playwright-driver (0.5.9)
       addressable
       capybara
       playwright-ruby-client (>= 1.16.0)
-    concurrent-ruby (1.3.4)
+    concurrent-ruby (1.3.6)
     connection_pool (2.4.1)
     crass (1.0.6)
     cssbundling-rails (1.4.1)
@@ -118,10 +118,7 @@ GEM
       railties (>= 6.1)
     drb (2.2.1)
     erubi (1.13.0)
-    ffi (1.17.0-aarch64-linux-gnu)
-    ffi (1.17.0-arm64-darwin)
-    ffi (1.17.0-x86_64-darwin)
-    ffi (1.17.0-x86_64-linux-gnu)
+    ffi (1.17.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
     i18n (1.14.6)
@@ -141,7 +138,7 @@ GEM
     json (2.7.2)
     language_server-protocol (3.17.0.3)
     lint_roller (1.1.0)
-    logger (1.6.1)
+    logger (1.7.0)
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -151,13 +148,14 @@ GEM
       net-pop
       net-smtp
     marcel (1.0.4)
-    matrix (0.4.2)
-    mime-types (3.6.0)
+    matrix (0.4.3)
+    mime-types (3.7.0)
       logger
-      mime-types-data (~> 3.2015)
-    mime-types-data (3.2024.1001)
+      mime-types-data (~> 3.2025, >= 3.2025.0507)
+    mime-types-data (3.2026.0414)
     mini_magick (4.13.2)
     mini_mime (1.1.5)
+    mini_portile2 (2.8.9)
     minitest (5.25.1)
     msgpack (1.7.3)
     net-imap (0.5.0)
@@ -170,19 +168,20 @@ GEM
     net-smtp (0.5.0)
       net-protocol
     nio4r (2.7.3)
-    nokogiri (1.16.7-aarch64-linux)
+    nokogiri (1.19.3-aarch64-linux-gnu)
       racc (~> 1.4)
-    nokogiri (1.16.7-arm64-darwin)
+    nokogiri (1.19.3-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.16.7-x86_64-darwin)
+    nokogiri (1.19.3-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.16.7-x86_64-linux)
+    nokogiri (1.19.3-x86_64-linux-gnu)
       racc (~> 1.4)
     parallel (1.26.3)
     parser (3.3.5.0)
       ast (~> 2.4.1)
       racc
-    playwright-ruby-client (1.47.0)
+    playwright-ruby-client (1.59.1)
+      base64
       concurrent-ruby (>= 1.1.6)
       mime-types (>= 3.0)
     prism (1.2.0)
@@ -193,14 +192,14 @@ GEM
       railties (>= 7.0.0)
     psych (5.1.2)
       stringio
-    public_suffix (6.0.1)
+    public_suffix (7.0.5)
     puma (6.4.3)
       nio4r (~> 2.0)
     racc (1.8.1)
-    rack (3.1.8)
+    rack (3.1.21)
     rack-session (2.0.0)
       rack (>= 3.0.0)
-    rack-test (2.1.0)
+    rack-test (2.2.0)
       rack (>= 1.3)
     rack_session_access (0.2.0)
       builder (>= 2.0.0)
@@ -243,7 +242,7 @@ GEM
       logger
     rdoc (6.7.0)
       psych (>= 4.0.0)
-    regexp_parser (2.9.2)
+    regexp_parser (2.12.0)
     reline (0.5.10)
       io-console (~> 0.5)
     rspec-core (3.13.2)
@@ -309,10 +308,8 @@ GEM
       railties (>= 3.1)
       slim (>= 3.0, < 6.0, != 5.0.0)
     sorbet-runtime (0.5.11611)
-    sqlite3 (2.1.1-aarch64-linux-gnu)
-    sqlite3 (2.1.1-arm64-darwin)
-    sqlite3 (2.1.1-x86_64-darwin)
-    sqlite3 (2.1.1-x86_64-linux-gnu)
+    sqlite3 (2.1.1)
+      mini_portile2 (~> 2.8.0)
     standard (1.35.0.1)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.0)
@@ -355,6 +352,7 @@ GEM
 PLATFORMS
   aarch64-linux
   arm64-darwin-22
+  arm64-darwin-25
   x86_64-darwin-22
   x86_64-linux
 

--- a/lib/shimmer/utils/remote_navigation.rb
+++ b/lib/shimmer/utils/remote_navigation.rb
@@ -33,8 +33,8 @@ module Shimmer
       end
 
       helper_method :popover_path
-      def popover_path(url, id: nil, selector: nil, placement: nil)
-        "javascript:ui.popover.open(#{{url: url, id: id, selector: selector, placement: placement}.compact.to_json})"
+      def popover_path(url, id: nil, selector: nil, placement: nil, classname: nil)
+        "javascript:ui.popover.open(#{{url: url, id: id, selector: selector, placement: placement, classname: classname}.compact.to_json})"
       end
 
       def shimmer_request?

--- a/lib/shimmer/utils/remote_navigation.rb
+++ b/lib/shimmer/utils/remote_navigation.rb
@@ -33,8 +33,8 @@ module Shimmer
       end
 
       helper_method :popover_path
-      def popover_path(url, id: nil, selector: nil, placement: nil, class_name: nil, placeholder_delay: nil)
-        "javascript:ui.popover.open(#{{url: url, id: id, selector: selector, placement: placement, className: class_name, placeholderDelay: placeholder_delay}.compact.to_json})"
+      def popover_path(url, id: nil, selector: nil, placement: nil, class_name: nil)
+        "javascript:ui.popover.open(#{{url: url, id: id, selector: selector, placement: placement, className: class_name}.compact.to_json})"
       end
 
       def shimmer_request?

--- a/lib/shimmer/utils/remote_navigation.rb
+++ b/lib/shimmer/utils/remote_navigation.rb
@@ -33,8 +33,8 @@ module Shimmer
       end
 
       helper_method :popover_path
-      def popover_path(url, id: nil, selector: nil, placement: nil, classname: nil)
-        "javascript:ui.popover.open(#{{url: url, id: id, selector: selector, placement: placement, classname: classname}.compact.to_json})"
+      def popover_path(url, id: nil, selector: nil, placement: nil, class_name: nil, placeholder_delay: nil)
+        "javascript:ui.popover.open(#{{url: url, id: id, selector: selector, placement: placement, className: class_name, placeholderDelay: placeholder_delay}.compact.to_json})"
       end
 
       def shimmer_request?

--- a/spec/rails_app/app/assets/stylesheets/application.sass.scss
+++ b/spec/rails_app/app/assets/stylesheets/application.sass.scss
@@ -1,5 +1,6 @@
 // Entry point for your Sass build
 @import "./modal.scss";
+@import "./popover.scss";
 @import "./modal_blind.scss";
 @import "../../../../../src/components/stack.scss";
 @import "./styleguide.scss";

--- a/spec/rails_app/app/assets/stylesheets/popover.scss
+++ b/spec/rails_app/app/assets/stylesheets/popover.scss
@@ -1,0 +1,13 @@
+.popover {
+  border: 1px solid black;
+  background-color: white;
+  padding: 20px;
+}
+
+.popover__placeholder {
+  background-color: violet;
+
+  &::before {
+    content: "Loading...";
+  }
+}

--- a/spec/rails_app/app/controllers/posts_controller.rb
+++ b/spec/rails_app/app/controllers/posts_controller.rb
@@ -27,6 +27,10 @@ class PostsController < ApplicationController
   def modal
   end
 
+  def popover
+    sleep 1
+  end
+
   private
 
   def post_params

--- a/spec/rails_app/app/views/posts/index.html.slim
+++ b/spec/rails_app/app/views/posts/index.html.slim
@@ -18,4 +18,4 @@ a href=modal_path(new_post_path, size: "custom-size") Write New Post
   h2 = post.title
   p = post.content
 
-a href=popover_path(popover_posts_path, placeholder_delay: 0) Open popover
+a href=popover_path(popover_posts_path) Open popover

--- a/spec/rails_app/app/views/posts/index.html.slim
+++ b/spec/rails_app/app/views/posts/index.html.slim
@@ -17,3 +17,5 @@ a href=modal_path(new_post_path, size: "custom-size") Write New Post
       = image_file_url(post.image, width: 200)
   h2 = post.title
   p = post.content
+
+a href=popover_path(popover_posts_path, placeholder_delay: 0) Open popover

--- a/spec/rails_app/app/views/posts/popover.html.slim
+++ b/spec/rails_app/app/views/posts/popover.html.slim
@@ -1,0 +1,1 @@
+h1 This is a popover!

--- a/spec/rails_app/config/routes.rb
+++ b/spec/rails_app/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
   resources :posts do
     collection do
       get :modal
+      get :popover
     end
 
     get :other, on: :collection

--- a/spec/system/popover_spec.rb
+++ b/spec/system/popover_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "system_helper"
+
+RSpec.describe "Popover" do
+  fixtures :all
+
+  it "opens and closes a popover" do
+    visit posts_path
+    expect(page).to have_link "Open popover"
+    expect(page).not_to have_selector ".popover"
+    expect(page).not_to have_content "This is a popover!"
+
+    click_on "Open popover"
+    expect(page).to have_selector ".popover"
+    expect(page).to have_content "This is a popover!"
+
+    find("h1", text: "Posts").click # Click somewhere outside the popover
+    expect(page).not_to have_selector ".popover"
+    expect(page).not_to have_content "This is a popover!"
+  end
+end

--- a/src/popover.ts
+++ b/src/popover.ts
@@ -6,7 +6,8 @@ export interface PopoverOptions {
   url: string;
   selector?: HTMLElement | string;
   placement?: Placement;
-  classname?: string;
+  className?: string;
+  placeholderDelay?: number;
 }
 
 export class PopoverPresenter {
@@ -48,7 +49,8 @@ export class Popover {
     url,
     selector,
     placement,
-    classname,
+    className,
+    placeholderDelay,
   }: PopoverOptions): Promise<void> {
     const root =
       typeof selector === "string"
@@ -58,12 +60,12 @@ export class Popover {
       return;
     }
 
-    const popoverClassname = ["popover"];
-    if (classname) {
-      popoverClassname.push(classname);
+    const popoverClassName = ["popover"];
+    if (className) {
+      popoverClassName.push(className);
     }
     const popoverDiv = document.createElement("div");
-    popoverDiv.className = popoverClassname.join(" ");
+    popoverDiv.className = popoverClassName.join(" ");
     const arrow = createElement(popoverDiv, "popover__arrow");
     arrow.setAttribute("data-popper-arrow", "true");
     this.popper = createPopper(root, popoverDiv, {
@@ -83,7 +85,7 @@ export class Popover {
     const placeholderTimeout = setTimeout(() => {
       createElement(content, "popover__placeholder");
       document.body.append(popoverDiv);
-    }, 300);
+    }, placeholderDelay ?? 300);
     getHTML(url).then((response) => {
       clearTimeout(placeholderTimeout);
       content.innerHTML = response;

--- a/src/popover.ts
+++ b/src/popover.ts
@@ -57,10 +57,11 @@ export class Popover {
     if (!root) {
       return;
     }
-    const popoverClassname = ["popover", classname]
-      .filter((obj) => obj)
-      .join(" ");
-    const popoverDiv = createElement(document.body, popoverClassname);
+    const popoverClassname = ["popover"];
+    if (classname) {
+      popoverClassname.push(classname);
+    }
+    const popoverDiv = createElement(document.body, popoverClassname.join(" "));
     const arrow = createElement(popoverDiv, "popover__arrow");
     arrow.setAttribute("data-popper-arrow", "true");
     this.popper = createPopper(root, popoverDiv, {

--- a/src/popover.ts
+++ b/src/popover.ts
@@ -57,11 +57,13 @@ export class Popover {
     if (!root) {
       return;
     }
+
     const popoverClassname = ["popover"];
     if (classname) {
       popoverClassname.push(classname);
     }
-    const popoverDiv = createElement(document.body, popoverClassname.join(" "));
+    const popoverDiv = document.createElement("div");
+    popoverDiv.className = popoverClassname.join(" ");
     const arrow = createElement(popoverDiv, "popover__arrow");
     arrow.setAttribute("data-popper-arrow", "true");
     this.popper = createPopper(root, popoverDiv, {
@@ -77,8 +79,17 @@ export class Popover {
     });
     this.popoverDiv = popoverDiv;
     const content = createElement(popoverDiv, "popover__content");
-    createElement(content, "popover__placeholder");
-    content.innerHTML = await getHTML(url);
+
+    const placeholderTimeout = setTimeout(() => {
+      createElement(content, "popover__placeholder");
+      document.body.append(popoverDiv);
+    }, 200);
+    getHTML(url).then((response) => {
+      clearTimeout(placeholderTimeout);
+      content.innerHTML = response;
+      document.body.append(popoverDiv);
+    });
+
     document.addEventListener("click", this.clickOutside);
   }
 

--- a/src/popover.ts
+++ b/src/popover.ts
@@ -84,11 +84,13 @@ export class Popover {
 
     const placeholderTimeout = setTimeout(() => {
       createElement(content, "popover__placeholder");
+      this.popper?.update();
       document.body.append(popoverDiv);
     }, placeholderDelay ?? 300);
     getHTML(url).then((response) => {
       clearTimeout(placeholderTimeout);
       content.innerHTML = response;
+      this.popper?.update();
       document.body.append(popoverDiv);
     });
 

--- a/src/popover.ts
+++ b/src/popover.ts
@@ -58,7 +58,7 @@ export class Popover {
       return;
     }
 
-    const popoverClassName = ["popover"];
+    const popoverClassName = ["popover", "popover--loading"];
     if (className) {
       popoverClassName.push(className);
     }
@@ -66,7 +66,6 @@ export class Popover {
     const arrow = createElement(popoverDiv, "popover__arrow");
     arrow.setAttribute("data-popper-arrow", "true");
     const content = createElement(popoverDiv, "popover__content");
-    createElement(content, "popover__placeholder");
     this.popper = createPopper(root, popoverDiv, {
       placement: placement ?? "auto",
       modifiers: [
@@ -80,11 +79,12 @@ export class Popover {
     });
     this.popoverDiv = popoverDiv;
 
+    document.addEventListener("click", this.clickOutside);
+
     const response = await getHTML(url);
     content.innerHTML = response;
+    popoverDiv.classList.remove("popover--loading");
     this.popper?.update();
-
-    document.addEventListener("click", this.clickOutside);
   }
 
   async close(): Promise<void> {

--- a/src/popover.ts
+++ b/src/popover.ts
@@ -54,8 +54,6 @@ export class Popover {
     const popoverDiv = createElement(document.body, "popover");
     const arrow = createElement(popoverDiv, "popover__arrow");
     arrow.setAttribute("data-popper-arrow", "true");
-    const content = createElement(popoverDiv, "popover__content");
-    content.innerHTML = await getHTML(url);
     this.popper = createPopper(root, popoverDiv, {
       placement: placement ?? "auto",
       modifiers: [
@@ -68,6 +66,8 @@ export class Popover {
       ],
     });
     this.popoverDiv = popoverDiv;
+    const content = createElement(popoverDiv, "popover__content");
+    content.innerHTML = await getHTML(url);
     document.addEventListener("click", this.clickOutside);
   }
 

--- a/src/popover.ts
+++ b/src/popover.ts
@@ -83,7 +83,7 @@ export class Popover {
     const placeholderTimeout = setTimeout(() => {
       createElement(content, "popover__placeholder");
       document.body.append(popoverDiv);
-    }, 200);
+    }, 300);
     getHTML(url).then((response) => {
       clearTimeout(placeholderTimeout);
       content.innerHTML = response;

--- a/src/popover.ts
+++ b/src/popover.ts
@@ -82,19 +82,17 @@ export class Popover {
     this.popoverDiv = popoverDiv;
     const content = createElement(popoverDiv, "popover__content");
 
-    const showPlaceholder = setTimeout(() => {
+    const placeholderTimeout = setTimeout(() => {
       createElement(content, "popover__placeholder");
       this.popper?.update();
       document.body.append(popoverDiv);
     }, placeholderDelay ?? 300);
-
-    const showContent = getHTML(url).then((response) => {
+    getHTML(url).then((response) => {
+      clearTimeout(placeholderTimeout);
       content.innerHTML = response;
       this.popper?.update();
       document.body.append(popoverDiv);
     });
-
-    await Promise.race([showPlaceholder, showContent]);
 
     document.addEventListener("click", this.clickOutside);
   }

--- a/src/popover.ts
+++ b/src/popover.ts
@@ -82,17 +82,19 @@ export class Popover {
     this.popoverDiv = popoverDiv;
     const content = createElement(popoverDiv, "popover__content");
 
-    const placeholderTimeout = setTimeout(() => {
+    const showPlaceholder = setTimeout(() => {
       createElement(content, "popover__placeholder");
       this.popper?.update();
       document.body.append(popoverDiv);
     }, placeholderDelay ?? 300);
-    getHTML(url).then((response) => {
-      clearTimeout(placeholderTimeout);
+
+    const showContent = getHTML(url).then((response) => {
       content.innerHTML = response;
       this.popper?.update();
       document.body.append(popoverDiv);
     });
+
+    await Promise.race([showPlaceholder, showContent]);
 
     document.addEventListener("click", this.clickOutside);
   }

--- a/src/popover.ts
+++ b/src/popover.ts
@@ -7,7 +7,6 @@ export interface PopoverOptions {
   selector?: HTMLElement | string;
   placement?: Placement;
   className?: string;
-  placeholderDelay?: number;
 }
 
 export class PopoverPresenter {
@@ -50,7 +49,6 @@ export class Popover {
     selector,
     placement,
     className,
-    placeholderDelay,
   }: PopoverOptions): Promise<void> {
     const root =
       typeof selector === "string"
@@ -64,10 +62,11 @@ export class Popover {
     if (className) {
       popoverClassName.push(className);
     }
-    const popoverDiv = document.createElement("div");
-    popoverDiv.className = popoverClassName.join(" ");
+    const popoverDiv = createElement(document.body, popoverClassName.join(" "));
     const arrow = createElement(popoverDiv, "popover__arrow");
     arrow.setAttribute("data-popper-arrow", "true");
+    const content = createElement(popoverDiv, "popover__content");
+    createElement(content, "popover__placeholder");
     this.popper = createPopper(root, popoverDiv, {
       placement: placement ?? "auto",
       modifiers: [
@@ -80,19 +79,10 @@ export class Popover {
       ],
     });
     this.popoverDiv = popoverDiv;
-    const content = createElement(popoverDiv, "popover__content");
 
-    const placeholderTimeout = setTimeout(() => {
-      createElement(content, "popover__placeholder");
-      this.popper?.update();
-      document.body.append(popoverDiv);
-    }, placeholderDelay ?? 300);
-    getHTML(url).then((response) => {
-      clearTimeout(placeholderTimeout);
-      content.innerHTML = response;
-      this.popper?.update();
-      document.body.append(popoverDiv);
-    });
+    const response = await getHTML(url);
+    content.innerHTML = response;
+    this.popper?.update();
 
     document.addEventListener("click", this.clickOutside);
   }

--- a/src/popover.ts
+++ b/src/popover.ts
@@ -77,6 +77,7 @@ export class Popover {
     });
     this.popoverDiv = popoverDiv;
     const content = createElement(popoverDiv, "popover__content");
+    createElement(content, "popover__placeholder");
     content.innerHTML = await getHTML(url);
     document.addEventListener("click", this.clickOutside);
   }

--- a/src/popover.ts
+++ b/src/popover.ts
@@ -6,6 +6,7 @@ export interface PopoverOptions {
   url: string;
   selector?: HTMLElement | string;
   placement?: Placement;
+  classname?: string;
 }
 
 export class PopoverPresenter {
@@ -43,7 +44,12 @@ export class Popover {
   private popper?: Popper;
   private popoverDiv?: HTMLDivElement;
 
-  async open({ url, selector, placement }: PopoverOptions): Promise<void> {
+  async open({
+    url,
+    selector,
+    placement,
+    classname,
+  }: PopoverOptions): Promise<void> {
     const root =
       typeof selector === "string"
         ? document.querySelector(selector)
@@ -51,7 +57,10 @@ export class Popover {
     if (!root) {
       return;
     }
-    const popoverDiv = createElement(document.body, "popover");
+    const popoverClassname = ["popover", classname]
+      .filter((obj) => obj)
+      .join(" ");
+    const popoverDiv = createElement(document.body, popoverClassname);
     const arrow = createElement(popoverDiv, "popover__arrow");
     arrow.setAttribute("data-popper-arrow", "true");
     this.popper = createPopper(root, popoverDiv, {


### PR DESCRIPTION
# Review Notes

This PR adds/changes the following:

- Re-order showing the popover and setting its content from the remote URL. This way, the popover can be shown immediately and content added later which improves UX.
- Add a new option `className` to popovers that can be used to add classes to the top-most `.popover` element.

This is how it looks like in the spec app:

https://github.com/user-attachments/assets/ad0423c5-9073-4651-b9f4-e87ec1acc0c0



